### PR TITLE
add function to output dict to json

### DIFF
--- a/jsoncore/core.py
+++ b/jsoncore/core.py
@@ -179,3 +179,19 @@ def get_keystrings(d, separator=SEPARATOR, wildcard=WILDCARD):
     """Given JSON data; generate a unique, sorted list of keystrings."""
     keys = get_keys(d, wildcard=wildcard)
     return map(join_keys(separator=SEPARATOR), keys)
+
+
+def format_json(data, compact=False, indent=2):
+    """
+    Format Dict to JSON.
+
+    Args:
+        data (dict): python dict
+        compact (boolean): non-indended output
+        indent (int): set indenting for compact=False mode
+
+    Returns:
+        data formatted to json-serialized content
+    """
+    separators = (',', ':') if compact else None
+    return json.dumps(data, indent=indent, separators=separators)

--- a/jsoncore/jsonfuncts.py
+++ b/jsoncore/jsonfuncts.py
@@ -6,7 +6,7 @@ from jsoncrawl import node_visitor
 
 from .core import (
     WILDCARD, SEPARATOR, SUPPRESS, del_key, get_item, get_keys, get_nodes,
-    get_value, join_keys, set_value
+    get_value, join_keys, set_value, get_keystrings
 )
 from .parse import parse_keys
 from .sequence import is_seq_and_not_str


### PR DESCRIPTION
Recommend adding this function to jsoncore, which will allow other packages to convert their dictionary to json before output to stdout.  This might be more appropriate in jsoncore since it's a "utility" function that many packages could utilize.