### PR TITLE
Function addition and import modification

### DIFF
--- a/jsoncore/core.py
+++ b/jsoncore/core.py
@@ -179,3 +179,19 @@ def get_keystrings(d, separator=SEPARATOR, wildcard=WILDCARD):
     """Given JSON data; generate a unique, sorted list of keystrings."""
     keys = get_keys(d, wildcard=wildcard)
     return map(join_keys(separator=SEPARATOR), keys)
+
+
+def format_json(data, compact=False, indent=2):
+    """
+    Format Dict to JSON.
+
+    Args:
+        data (dict): python dict
+        compact (boolean): non-indended output
+        indent (int): set indenting for compact=False mode
+
+    Returns:
+        data formatted to json-serialized content
+    """
+    separators = (',', ':') if compact else None
+    return json.dumps(data, indent=indent, separators=separators)

--- a/jsoncore/jsonfuncts.py
+++ b/jsoncore/jsonfuncts.py
@@ -6,7 +6,7 @@ from jsoncrawl import node_visitor
 
 from .core import (
     WILDCARD, SEPARATOR, SUPPRESS, del_key, get_item, get_keys, get_nodes,
-    get_value, join_keys, set_value
+    get_value, join_keys, set_value, get_keystrings
 )
 from .parse import parse_keys
 from .sequence import is_seq_and_not_str


### PR DESCRIPTION
PR to do the following:

1.  Adds a "utility" function to jsoncore.core, which just outputs a python dict to JSON.  I think this is function that might be more appropriately placed in JSON Core since many other packages can use it.

2.  Updates the import statement in jsoncore.jsonfuncts.  get_keystrings() is called by jsonkeys(), but it is not imported by jsonfuncts.py